### PR TITLE
feat: add option to install a specific EspoCRM version

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,14 @@ wget https://github.com/espocrm/espocrm-installer/releases/latest/download/insta
 sudo bash install.sh -y --ssl --letsencrypt --domain=my-espocrm.com --email=email@my-domain.com
 ```
 
+You can also specify a particular EspoCRM version to install:
+
+```
+sudo bash install.sh --version=8.4.2
+```
+
+If no version is specified, the latest version will be installed.
+
 ## Run (only for development)
 
 ```


### PR DESCRIPTION
closes #6 

I've tested this with a new installation and it works as expected.

If you'd like to test, you can use the code from our fork like so:

```bash
wget https://raw.githubusercontent.com/rodekruis/espocrm-installer/refs/heads/master/install.sh
chmod +x install.sh # only necessary because of how we are downloading the file differently and not via a release - would not be necessary normally
sudo bash install.sh --version=8.4.2 # you can add any of the other command line parameters here
```

I think this is a nice addition, and valuable for the community, but I am also very open to feedback and adjustments if needed.